### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/JLCodeSource/process_async_ds/security/code-scanning/1](https://github.com/JLCodeSource/process_async_ds/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only requires read access to the repository contents (e.g., to check out the code), the permissions can be set to `contents: read`. This ensures the workflow operates with the least privilege necessary.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. Alternatively, it can be added to the specific job (`build`) if different jobs require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
